### PR TITLE
Working devstack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,8 +56,8 @@ services:
   lms:
     build:
       context: ./edxapp
-      args:
-        service_variant: lms
+    environment:
+      SERVICE_VARIANT: lms
     restart: unless-stopped
     volumes:
       - ./data/lms:/openedx/data
@@ -71,8 +71,8 @@ services:
   cms:
     build:
       context: ./edxapp
-      args:
-        service_variant: cms
+    environment:
+      SERVICE_VARIANT: cms
     restart: unless-stopped
     volumes:
       - ./data/cms:/openedx/data
@@ -85,9 +85,9 @@ services:
   lms_worker:
     build:
       context: ./edxapp
-      args:
-        service_variant: lms
-    command: ./manage.py lms --settings=production celery worker --loglevel=info --hostname=edx.lms.core.default.%%h --maxtasksperchild 100
+    environment:
+      SERVICE_VARIANT: lms
+    command: ./manage.py lms celery worker --loglevel=info --hostname=edx.lms.core.default.%%h --maxtasksperchild 100
     restart: unless-stopped
     environment:
       C_FORCE_ROOT: "1" # run celery tasks as root #nofear
@@ -99,9 +99,9 @@ services:
   cms_worker:
     build:
       context: ./edxapp
-      args:
-        service_variant: cms
-    command: ./manage.py cms --settings=production celery worker --loglevel=info --hostname=edx.cms.core.default.%%h --maxtasksperchild 100
+    environment:
+      SERVICE_VARIANT: cms
+    command: ./manage.py cms celery worker --loglevel=info --hostname=edx.cms.core.default.%%h --maxtasksperchild 100
     restart: unless-stopped
     environment:
       C_FORCE_ROOT: "1" # run celery tasks as root #nofear

--- a/edxapp/Dockerfile
+++ b/edxapp/Dockerfile
@@ -23,15 +23,19 @@ VOLUME /openedx/data
 WORKDIR /openedx/edx-platform
 
 ## Checkout edx-platform code
-RUN git clone https://github.com/edx/edx-platform.git --branch open-release/ginkgo.master --depth 1 .
+ARG EDX_PLATFORM_REPOSITORY=https://github.com/edx/edx-platform.git
+ARG EDX_PLATFORM_VERSION=open-release/ginkgo.master
+RUN git clone $EDX_PLATFORM_REPOSITORY --branch $EDX_PLATFORM_VERSION --depth 1 .
+VOLUME /openedx/edx-platform
 
-# Install python requirements
-RUN pip install -r requirements/edx/pre.txt
-RUN pip install -r requirements/edx/github.txt
-RUN pip install -r requirements/edx/local.txt
-RUN pip install -r requirements/edx/base.txt
-RUN pip install -r requirements/edx/post.txt
-RUN pip install -r requirements/edx/paver.txt
+# Install python requirements (clone source repos in a separate dir, otherwise
+# will be overwritten when we mount edx-platform)
+RUN pip install --src ../venv/src -r requirements/edx/pre.txt
+RUN pip install --src ../venv/src -r requirements/edx/github.txt
+RUN pip install --src ../venv/src -r requirements/edx/local.txt
+RUN pip install --src ../venv/src -r requirements/edx/base.txt
+RUN pip install --src ../venv/src -r requirements/edx/post.txt
+RUN pip install --src ../venv/src -r requirements/edx/paver.txt
 
 # Install nodejs requirements
 RUN npm install
@@ -46,17 +50,16 @@ COPY ./config/cms.env.json /openedx/
 COPY ./config/lms.auth.json /openedx/
 COPY ./config/cms.auth.json /openedx/
 
-# Copy convenient script
-COPY ./wait-for-greenlight.sh .
-
-############ End of code common to lms & cms
+# Copy convenient scripts
+COPY ./wait-for-greenlight.sh /usr/local/bin/
+COPY ./docker-entrypoint.sh /usr/local/bin/
 
 # service variant is "lms" or "cms"
-ARG service_variant
+ENV SERVICE_VARIANT lms
+ENV SETTINGS production
 
-# Configure environment
-ENV DJANGO_SETTINGS_MODULE ${service_variant}.envs.production
-ENV SERVICE_VARIANT ${service_variant}
+# Entrypoint will fix permissiosn of all files and run commands as openedx
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 # Run server
 EXPOSE 8000

--- a/edxapp/docker-entrypoint.sh
+++ b/edxapp/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+export DJANGO_SETTINGS_MODULE=$SERVICE_VARIANT.envs.$SETTINGS
+USERID=${USERID:=1000}
+
+## Configure user with a different USERID if requested.
+if [ "$USERID" -ne 1000 ]
+    then
+        echo "creating new user 'openedx' with UID $USERID"
+        useradd -m openedx -u $USERID
+        chown -R openedx /openedx
+
+        # Run CMD as different user
+        exec chroot --userspec="$USERID" --skip-chdir / "$@"
+else 
+        # Run CMD as root (business as usual)
+        exec "$@"
+fi

--- a/edxapp/wait-for-greenlight.sh
+++ b/edxapp/wait-for-greenlight.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Checking system..."
-until ./manage.py lms --settings=production check
+until ./manage.py $SERVICE_VARIANT check
 do
   printf "."
   sleep 1


### PR DESCRIPTION
This allows the user to run their own devstack inside the containers.
Yay!

Also, we handle file permissions cleanly: in `docker-entrypoint.sh` we chmod the data and edx-platform files to the same UID of the user on the host machine. No more permission headaches!

@natea  @sampaccoud can you give it a try? I think it's pretty neat ;)