### PR TITLE
Fixes #62: Use non-overlapping username variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This will launch the various docker containers required for your Open edX platfo
 
 You will most certainly need to create a user to administer the platform. Just run:
 
-    USERNAME=yourusername EMAIL=user@email.com make create-staff-user
+    make create-staff-user USERNAME=yourusername EMAIL=user@email.com
 
 You will asked to set the user password interactively.
 


### PR DESCRIPTION
`$USERNAME` is a special variable in `zsh` and so when we try to set the staff's username to it, it gets the wrong thing. Using STAFFUSERNAME negates this issue. While the command clearly uses `/bin/bash` for the shell, this is getting interpolated prior to hitting that shell (on my machine anyways).

I understand that you may not want to support ZSH so feel free to close this if desired.