### PR TITLE
Update docker-compose.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 config/
 data-*/
 TODO
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,8 +41,8 @@ services:
     image: nginx:1.13
     restart: unless-stopped
     ports:
-      - "80:80"
-      - "443:443"
+      - "${OPENEDX_NGINX_PORT:-80}:80"
+      - "${OPENEDX_NGINX_TLSPORT:-443}443:443"
     volumes:
       - ./config/nginx:/etc/nginx/conf.d/
       - ./data/lms:/openedx/data/lms:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,8 +41,8 @@ services:
     image: nginx:1.13
     restart: unless-stopped
     ports:
-      - "${OPENEDX_NGINX_PORT:-80}:80"
-      - "${OPENEDX_NGINX_TLSPORT:-443}443:443"
+      - "${NGINX_HTTP_PORT:-80}:80"
+      - "${NGINX_HTTPS_PORT:-443}:443"
     volumes:
       - ./config/nginx:/etc/nginx/conf.d/
       - ./data/lms:/openedx/data/lms:ro


### PR DESCRIPTION
Added optional alternate ports for nginx to aid in proxy pass deployments without needing to edit docker-compose file.

To deploy with alternate ports, add a `.env` file with the following contents:

```
OPENEDX_NGINX_PORT=8080
OPENEDX_NGINX_TLSPORT=8443
```

The .env file should not be added to the repository.