### PR TITLE
 Make running containers as the host user optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ endif
 ifeq ($(ACTIVATE_HTTPS), 1)
 	post_configure_targets += https-certificate
 endif
-extra_migrate_targets = 
+extra_migrate_targets =
 ifeq ($(ACTIVATE_XQUEUE), 1)
 	extra_migrate_targets += migrate-xqueue
 	DOCKER_COMPOSE += -f docker-compose-xqueue.yml
@@ -131,7 +131,7 @@ assets-development-cms:
 		&& NODE_ENV=development ./node_modules/.bin/webpack --config=webpack.dev.config.js \
 		&& ./manage.py cms --settings=$(EDX_PLATFORM_SETTINGS) compile_sass studio \
 		&& python -c \"import pavelib.assets; pavelib.assets.collect_assets(['studio'], '$(EDX_PLATFORM_SETTINGS)')\""
-	
+
 
 ##################### Information
 

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,17 @@ endif
 ifeq ($(ACTIVATE_PORTAINER), 1)
 	DOCKER_COMPOSE += -f docker-compose-portainer.yml
 endif
+DOCKER_USER_OPTIONS =
+ifeq ($(DONT_RUN_AS_ROOT), 1)
+	DOCKER_USER_OPTIONS = -e USERID=$(USERID)
+endif
+
+ifeq ($(ACTIVATE_PORTAINER), 1)
+	DOCKER_COMPOSE += -f docker-compose-portainer.yml
+endif
 
 DOCKER_COMPOSE_RUN = $(DOCKER_COMPOSE) run --rm
-DOCKER_COMPOSE_RUN_OPENEDX = $(DOCKER_COMPOSE_RUN) -e USERID=$(USERID) -e SETTINGS=$(EDX_PLATFORM_SETTINGS)
+DOCKER_COMPOSE_RUN_OPENEDX = $(DOCKER_COMPOSE_RUN) $(DOCKER_USER_OPTIONS) -e SETTINGS=$(EDX_PLATFORM_SETTINGS)
 ifneq ($(EDX_PLATFORM_PATH),)
 	DOCKER_COMPOSE_RUN_OPENEDX += --volume="$(EDX_PLATFORM_PATH):/openedx/edx-platform"
 endif
@@ -64,7 +72,7 @@ stop: ## Stop all services
 
 configure: build-configurator ## Configure the environment prior to running the platform
 	docker run --rm -it --volume="$(PWD)/config:/openedx/config" \
-		-e USERID=$(USERID) -e SILENT=$(SILENT) $(CONFIGURE_OPTS) \
+		$(DOCKER_USER_OPTIONS) -e SILENT=$(SILENT) $(CONFIGURE_OPTS) \
 		regis/openedx-configurator:hawthorn
 
 post_configure: $(post_configure_targets)
@@ -180,7 +188,7 @@ build-notes: ## Build the Notes docker image
 	docker build -t regis/openedx-notes:latest -t regis/openedx-notes:hawthorn notes/
 build-xqueue: ## Build the Xqueue docker image
 	docker build -t regis/openedx-xqueue:latest -t regis/openedx-xqueue:hawthorn xqueue/
-build-android: ## Build the docker image for Android 
+build-android: ## Build the docker image for Android
 	docker build -t regis/openedx-android:latest android/
 
 ################### Pushing images to docker hub

--- a/configurator/bin/configure.py
+++ b/configurator/bin/configure.py
@@ -175,6 +175,8 @@ def interactive(args):
         'ACTIVATE_PORTAINER', "Activate Portainer, a convenient Docker dashboard with a web UI (https://portainer.io)?", False
     ).add_bool(
         'ACTIVATE_XQUEUE', "Activate Xqueue for external grader services? (https://github.com/edx/xqueue)", False
+    ).add_bool(
+        'DONT_RUN_AS_ROOT', "Do you want edx services inside the containers to run using the same id as the user launching the containers?", True
     ).add(
         'ID', "", random_string(8)
     )


### PR DESCRIPTION
The chown operation inside docker-entrypoint.sh is extremely costly.

By virtue of how docker works, it requires a full copy of all files
that need an owner change.
See https://medium.com/@lmakarov/the-backlash-of-chmod-chown-mv-in-your-dockerfile-f12fe08c0b55

This amounts to more than 60k files and more than one GB.
It takes time and space to copy all these files.

This PR makes it possible to opt out and not have the `chown` command invoked on every container startup.